### PR TITLE
Revert "Make Alt be Altmode."

### DIFF
--- a/dp3300.c
+++ b/dp3300.c
@@ -290,7 +290,7 @@ char *argv0;
 void
 usage(void)
 {
-	panic("usage: %s [-a] [-B] [-b baudrate]", argv0);
+	panic("usage: %s [-B] [-b baudrate]", argv0);
 }
 
 int
@@ -305,9 +305,6 @@ main(int argc, char *argv[])
 	scancodemap = scancodemap_upper;
 
 	ARGBEGIN{
-	case 'a':
-		altesc = 1;
-		break;
 	case 'b':
 		baud = atoi(EARGF(usage()));
 		break;

--- a/terminal.c
+++ b/terminal.c
@@ -142,9 +142,6 @@ char *scancodemap_both[SDL_NUM_SCANCODES] = {
 	[SDL_SCANCODE_PERIOD] = ".>",
 	[SDL_SCANCODE_SLASH] = "/?",
 	[SDL_SCANCODE_SPACE] = "  ",
-
-	[SDL_SCANCODE_LALT] = "\033\033",
-	[SDL_SCANCODE_RALT] = "\033\033",
 };
 
 char *scancodemap_upper[SDL_NUM_SCANCODES] = {
@@ -205,15 +202,11 @@ char *scancodemap_upper[SDL_NUM_SCANCODES] = {
 	[SDL_SCANCODE_PERIOD] = ".>",
 	[SDL_SCANCODE_SLASH] = "/?",
 	[SDL_SCANCODE_SPACE] = "  ",
-
-	[SDL_SCANCODE_LALT] = "\033\033",
-	[SDL_SCANCODE_RALT] = "\033\033",
 };
 
 int ctrl;
 int shift;
 int alt;
-int altesc;
 
 void
 keydown(SDL_Keysym keysym, int repeat)
@@ -231,11 +224,10 @@ keydown(SDL_Keysym keysym, int repeat)
 	}
 	if(keystate[SDL_SCANCODE_LGUI] || keystate[SDL_SCANCODE_RGUI])
 		return;
-	if(keysym.scancode == SDL_SCANCODE_LALT || keysym.scancode == SDL_SCANCODE_RALT)
-		if(!altesc){
-			alt = 1;
-			return;
-		}
+	if(keysym.scancode == SDL_SCANCODE_LALT || keysym.scancode == SDL_SCANCODE_RALT) {
+		alt = 1;
+		return;
+	}
 
 	if(keysym.scancode == SDL_SCANCODE_F11 && !repeat){
 		u32 f = SDL_GetWindowFlags(window) &

--- a/vt05.c
+++ b/vt05.c
@@ -315,7 +315,7 @@ char *argv0;
 void
 usage(void)
 {
-	panic("usage: %s [-a] [-B] [-b baudrate]", argv0);
+	panic("usage: %s [-B] [-b baudrate]", argv0);
 }
 
 int
@@ -330,9 +330,6 @@ main(int argc, char *argv[])
 	scancodemap = scancodemap_upper;
 
 	ARGBEGIN{
-	case 'a':
-		altesc = 1;
-		break;
 	case 'b':
 		baud = atoi(EARGF(usage()));
 		break;

--- a/vt52.c
+++ b/vt52.c
@@ -358,7 +358,7 @@ char *argv0;
 void
 usage(void)
 {
-	panic("usage: %s [-a] [-B] [-b baudrate]", argv0);
+	panic("usage: %s [-B] [-b baudrate]", argv0);
 }
 
 int
@@ -373,9 +373,6 @@ main(int argc, char *argv[])
 	scancodemap = scancodemap_both;
 
 	ARGBEGIN{
-	case 'a':
-		altesc = 1;
-		break;
 	case 'b':
 		baud = atoi(EARGF(usage()));
 		break;


### PR DESCRIPTION
It was not a good idea, because repeated Alt+key presses don't work.  Alt is still a modifier which sends an Altmode prefix.