### PR TITLE
Add compiler warnings?

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 all: vt05 vt52 dp3300 gecon dm2500
+WARN=-Wall -Wno-unused-parameter -Wno-parentheses -Wno-unused-result
 DEPS=`sdl2-config --libs --cflags` -lm -lpthread
 vt05: vt05.c terminal.c vt05chars.h args.h
-	cc -O3 -o vt05 vt05.c terminal.c $(DEPS)
+	cc $(WARN) -O3 -o vt05 vt05.c terminal.c $(DEPS)
 vt52: vt52.c terminal.c vt52rom.h args.h
-	cc -O3 -o vt52 vt52.c terminal.c $(DEPS)
+	cc $(WARN) -O3 -o vt52 vt52.c terminal.c $(DEPS)
 dp3300: dp3300.c terminal.c dpchars.h args.h
-	cc -O3 -o dp3300 dp3300.c terminal.c $(DEPS)
+	cc $(WARN) -O3 -o dp3300 dp3300.c terminal.c $(DEPS)
 gecon: gecon.c terminal.c dpchars.h args.h
-	cc -O3 -o $@ gecon.c terminal.c $(DEPS)
+	cc $(WARN) -O3 -o $@ gecon.c terminal.c $(DEPS)
 dm2500: dm2500.c terminal.c dmchars.h args.h
-	cc -O3 -o dm2500 dm2500.c terminal.c $(DEPS)
+	cc $(WARN) -O3 -o dm2500 dm2500.c terminal.c $(DEPS)

--- a/args.h
+++ b/args.h
@@ -2,7 +2,7 @@ extern char *argv0;
 #define USED(x) ((void)x)
 #define SET(x) ((x)=0)
 
-#define	ARGBEGIN	for((argv0||(argv0=*argv)),argv++,argc--;\
+#define	ARGBEGIN	for((void)(argv0||(argv0=*argv)),argv++,argc--;\
 			    argv[0] && argv[0][0]=='-' && argv[0][1];\
 			    argc--, argv++) {\
 				char *_args, *_argt;\

--- a/dm2500.c
+++ b/dm2500.c
@@ -106,7 +106,7 @@ blurchar(u32 *dst, u32 *src)
 void
 createfont(void)
 {
-	int i, j;
+	int i;
 	int w, h;
 	u32 *ras1, *ras2;
 	w = TEXW;
@@ -342,7 +342,6 @@ int
 main(int argc, char *argv[])
 {
 	SDL_Event ev;
-	int mod;
 	int x, y;
 	pthread_t thr1, thr2;
 	struct winsize ws;

--- a/dp3300.c
+++ b/dp3300.c
@@ -114,7 +114,7 @@ blurchar(u32 *dst, u32 *src)
 void
 createfont(void)
 {
-	int i, j;
+	int i;
 	int w, h;
 	u32 *ras1, *ras2;
 	w = TEXW;
@@ -309,7 +309,6 @@ int
 main(int argc, char *argv[])
 {
 	SDL_Event ev;
-	int mod;
 	int x, y;
 	pthread_t thr1, thr2;
 	struct winsize ws;

--- a/gecon.c
+++ b/gecon.c
@@ -106,7 +106,7 @@ blurchar(u32 *dst, u32 *src)
 void
 createfont(void)
 {
-	int i, j;
+	int i;
 	int w, h;
 	u32 *ras1, *ras2;
 	w = TEXW;
@@ -275,7 +275,6 @@ int
 main(int argc, char *argv[])
 {
 	SDL_Event ev;
-	int mod;
 	int x, y;
 	pthread_t thr1, thr2;
 	struct winsize ws;

--- a/terminal.c
+++ b/terminal.c
@@ -72,13 +72,12 @@ void
 initblur(float sig)
 {
 	int i, j;
-	float dx, dy, dist;
+	float dx, dy;
 
 	for(i = 0; i < MATSIZ; i++)
 		for(j = 0; j < MATSIZ; j++){
 			dx = i-BLURRADIUS;
 			dy = j-BLURRADIUS;
-			dist = sqrt(dx*dx + dy*dy);
 			blurmat[i][j] = exp(-(dx*dx + dy*dy)/(2*sig*sig)) / (2*M_PI*sig*sig);
 		}
 }
@@ -234,6 +233,7 @@ keydown(SDL_Keysym keysym, int repeat)
 	case SDL_SCANCODE_CAPSLOCK:
 	case SDL_SCANCODE_LCTRL:
 	case SDL_SCANCODE_RCTRL: ctrl = 1; return;
+	default: break;
 	}
 	if(keystate[SDL_SCANCODE_LGUI] || keystate[SDL_SCANCODE_RGUI])
 		return;
@@ -281,6 +281,7 @@ keyup(SDL_Keysym keysym)
 	case SDL_SCANCODE_RCTRL: ctrl = 0; return;
 	case SDL_SCANCODE_LALT:
 	case SDL_SCANCODE_RALT: alt = 0; return;
+	default: break;
 	}
 }
 

--- a/vt05.c
+++ b/vt05.c
@@ -105,7 +105,7 @@ blurchar(u32 *dst, u32 *src)
 void
 createfont(void)
 {
-	int i, j;
+	int i;
 	int w, h;
 	u32 *ras1, *ras2;
 	w = TEXW;
@@ -187,7 +187,6 @@ mapchar(char c)
 void
 recvchar(int c)
 {
-	char pc;
 	int x, y;
 
 	/* Handle cursor addresing */
@@ -326,9 +325,8 @@ int
 main(int argc, char *argv[])
 {
 	SDL_Event ev;
-	int mod;
 	int x, y;
-	pthread_t thr1, thr2;
+	pthread_t thr1;
 	struct winsize ws;
 
 	scancodemap = scancodemap_upper;

--- a/vt52.c
+++ b/vt52.c
@@ -105,7 +105,7 @@ blurchar(u32 *dst, u32 *src)
 void
 createfont(void)
 {
-	int i, j;
+	int i;
 	int w, h;
 	u32 *ras1, *ras2;
 	w = TEXW;
@@ -369,7 +369,6 @@ int
 main(int argc, char *argv[])
 {
 	SDL_Event ev;
-	int mod;
 	int x, y;
 	pthread_t thr1, thr2;
 	struct winsize ws;


### PR DESCRIPTION
I see a distinct lack of compiler warnings in the Makefile.  Maybe that's the way you like it, but I found that using the selection `-Wall -Wno-unused-parameter -Wno-parentheses -Wno-unused-result` seems to cover a reasonable amount of questionable code without too much pain.