### PR TITLE
Move inclusion of SDL.h to the top.

### DIFF
--- a/dm2500.c
+++ b/dm2500.c
@@ -1,6 +1,7 @@
 #define _XOPEN_SOURCE 600
 #define _DEFAULT_SOURCE
 
+#include <SDL.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -16,7 +17,6 @@
 #include <poll.h>
 #include <errno.h>
 #include <pthread.h>
-#include <SDL.h>
 #include <assert.h>
 #include <math.h>
 

--- a/dp3300.c
+++ b/dp3300.c
@@ -1,6 +1,7 @@
 #define _XOPEN_SOURCE 600
 #define _DEFAULT_SOURCE
 
+#include <SDL.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -16,7 +17,6 @@
 #include <poll.h>
 #include <errno.h>
 #include <pthread.h>
-#include <SDL.h>
 #include <assert.h>
 #include <math.h>
 

--- a/gecon.c
+++ b/gecon.c
@@ -1,6 +1,7 @@
 #define _XOPEN_SOURCE 600
 #define _DEFAULT_SOURCE
 
+#include <SDL.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -16,7 +17,6 @@
 #include <poll.h>
 #include <errno.h>
 #include <pthread.h>
-#include <SDL.h>
 #include <assert.h>
 #include <math.h>
 

--- a/vt05.c
+++ b/vt05.c
@@ -1,6 +1,7 @@
 #define _XOPEN_SOURCE 600
 #define _DEFAULT_SOURCE
 
+#include <SDL.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -16,7 +17,6 @@
 #include <poll.h>
 #include <errno.h>
 #include <pthread.h>
-#include <SDL.h>
 #include <assert.h>
 
 #include "terminal.h"

--- a/vt50.c
+++ b/vt50.c
@@ -1,6 +1,7 @@
 #define _XOPEN_SOURCE 600
 #define _DEFAULT_SOURCE
 
+#include <SDL.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -16,7 +17,6 @@
 #include <poll.h>
 #include <errno.h>
 #include <pthread.h>
-#include <SDL.h>
 #include <assert.h>
 
 #include "terminal.h"

--- a/vt52.c
+++ b/vt52.c
@@ -1,6 +1,7 @@
 #define _XOPEN_SOURCE 600
 #define _DEFAULT_SOURCE
 
+#include <SDL.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -16,7 +17,6 @@
 #include <poll.h>
 #include <errno.h>
 #include <pthread.h>
-#include <SDL.h>
 #include <assert.h>
 
 #include "terminal.h"


### PR DESCRIPTION
Avoids problem described by @gwright83 in issue #20.