### PR TITLE
Fix window title for VT05 emulator

### DIFF
--- a/vt05.c
+++ b/vt05.c
@@ -370,7 +370,7 @@ main(int argc, char *argv[])
 	mkpty(&ws, TERMHEIGHT, TERMWIDTH, FBWIDTH, FBHEIGHT);
 	spawn();
 
-	mkwindow(&window, &renderer, "Datapoint 3300", WIDTH*scale, HEIGHT*scale);
+	mkwindow(&window, &renderer, "VT05", WIDTH*scale, HEIGHT*scale);
 
 	screentex = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888,
 			SDL_TEXTUREACCESS_TARGET, WIDTH, HEIGHT);


### PR DESCRIPTION
Simple update to window title string for VT05 to say "VT05"