### PR TITLE
Fix typo in Datamedia Elite 2500 window title

### DIFF
--- a/dm2500.c
+++ b/dm2500.c
@@ -363,7 +363,7 @@ main(int argc, char *argv[])
 	mkpty(&ws, TERMHEIGHT, TERMWIDTH, FBWIDTH, FBHEIGHT);
 	spawn();
 
-	mkwindow(&window, &renderer, "Datamedial Elite 2500", WIDTH*scale, HEIGHT*scale);
+	mkwindow(&window, &renderer, "Datamedia Elite 2500", WIDTH*scale, HEIGHT*scale);
 
 	screentex = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888,
 			SDL_TEXTUREACCESS_TARGET, WIDTH, HEIGHT);

--- a/vt05.c
+++ b/vt05.c
@@ -370,7 +370,7 @@ main(int argc, char *argv[])
 	mkpty(&ws, TERMHEIGHT, TERMWIDTH, FBWIDTH, FBHEIGHT);
 	spawn();
 
-	mkwindow(&window, &renderer, "Datapoint 3300", WIDTH*scale, HEIGHT*scale);
+	mkwindow(&window, &renderer, "VT05", WIDTH*scale, HEIGHT*scale);
 
 	screentex = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888,
 			SDL_TEXTUREACCESS_TARGET, WIDTH, HEIGHT);


### PR DESCRIPTION
Simple typo in name of the vendor.